### PR TITLE
chore: stop checking go version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 .DEFAULT_GOAL = help
 
-GO-VERSION = 1.22.0
-GO-VER = go$(GO-VERSION)
-
 SRC = $(shell find . -name "*.go" | grep -v "_test\." )
 
 .PHONY: help
@@ -10,9 +7,9 @@ help: ## list Makefile targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: test
-test: version download ginkgo ## run all build, static analysis, and test steps
+test: download ginkgo ## run all build, static analysis, and test steps
 
-build: version download $(SRC) ## build the provider
+build: download $(SRC) ## build the provider
 	goreleaser build --rm-dist --snapshot
 
 .PHONY: clean
@@ -35,11 +32,3 @@ ginkgo-coverage: ## ginkgo coverage score
 	paste -sd "," /tmp/tpcsbmysql-non-fake.txt > /tmp/tpcsbmysql-pkgs.txt
 	go test -coverpkg=`cat /tmp/tpcsbmysql-pkgs.txt` -coverprofile=/tmp/tpcsbmysql-coverage.out ./...
 	go tool cover -func /tmp/tpcsbmysql-coverage.out | grep total
-
-.PHONY: version
-version:
-	@@go version
-	@@if [ "$$(go version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$(go version | awk '{print $$3}')"; \
-		exit 1; \
-	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/terraform-provider-csbmysql
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1


### PR DESCRIPTION
[#187027977](https://www.pivotaltracker.com/story/show/187027977)

Before Go 1.21:
- The go directive was advisory only; now it is a mandatory requirement
- The go directive didn't allow specifying patch versions

So, by specifying the patch version in go.mod:
- Noone can unknowingly test, run or build this project using an older version of go
- The required Go toolchain can be downloaded automatically

Therefore, checking the current go version in Makefile is no longer needed.