### PR TITLE
fix: Go 1.22 broke compatibility with Mysql 5.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        mysql_version: ["8", "5.7"]
+        mysql_version: ["8", "5.7-debian", "8-debian"]
     runs-on: ubuntu-latest
     name: Go test
     outputs:

--- a/csbmysql/resource_binding_user_test.go
+++ b/csbmysql/resource_binding_user_test.go
@@ -241,15 +241,8 @@ func checkSSLCipher(requireSSL bool) resource.TestCheckFunc {
 		Expect(err).NotTo(HaveOccurred())
 		Expect("Ssl_cipher").To(Equal(res.VariableName))
 
-		var expectedCipher string
-		switch getMySQLVersion() {
-		case latestMySQLVersion:
-			expectedCipher = "TLS_AES_128_GCM_SHA256"
-			Expect(expectedCipher).To(Equal(res.Value))
-		default:
-			expectedCipher = "AES128-GCM-SHA256"
-			Expect(expectedCipher).To(Equal(res.Value))
-		}
+		expectedCiphers := []string{"TLS_AES_128_GCM_SHA256", "AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256"}
+		Expect(expectedCiphers).To(ContainElement(res.Value))
 		return nil
 	}
 }

--- a/csbmysql/resource_binding_user_test.go
+++ b/csbmysql/resource_binding_user_test.go
@@ -239,10 +239,13 @@ func checkSSLCipher(requireSSL bool) resource.TestCheckFunc {
 		err = db.QueryRow("SHOW STATUS LIKE 'Ssl_cipher'").Scan(&res.VariableName, &res.Value)
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect("Ssl_cipher").To(Equal(res.VariableName))
+		Expect(res.VariableName).To(Equal("Ssl_cipher"))
 
-		expectedCiphers := []string{"TLS_AES_128_GCM_SHA256", "AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256"}
-		Expect(expectedCiphers).To(ContainElement(res.Value))
+		Expect(res.Value).To(SatisfyAny(
+			Equal("TLS_AES_128_GCM_SHA256"),
+			Equal("AES128-GCM-SHA256"),
+			Equal("ECDHE-RSA-AES128-GCM-SHA256"),
+		))
 		return nil
 	}
 }


### PR DESCRIPTION
[#187028341](https://www.pivotaltracker.com/story/show/187028341)

Apparently, mysql tag `5.7` is equivalent to `5.7-oracle`. Also, it seems that there is an alternative tag named `5.7-debian`. I ran some tests locally and they return different results. As such, fixing this issue (which might occur when running against one image but not against another) is not very useful.

Still, this change tries to workaround the issue for now by changing the Docker image we use. However, we should tests against a real AWS instance to really check if the TLS issue also happens in AWS.