### PR TITLE
chore: apply fixes from Go modernize command

### DIFF
--- a/csbmysql/csbmysql_suite_test.go
+++ b/csbmysql/csbmysql_suite_test.go
@@ -112,7 +112,7 @@ func executeSql(db *sql.DB, statement string) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func parse(m interface{}, resourceTmpl string) (string, error) {
+func parse(m any, resourceTmpl string) (string, error) {
 	var definitionBytes bytes.Buffer
 
 	t := template.Must(template.New("resource").Parse(resourceTmpl))


### PR DESCRIPTION
The modernize command replaces old constructs with simpler, updated ones.

Command is:
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...